### PR TITLE
fixed typo for javadoc

### DIFF
--- a/src/magick/Magick.java
+++ b/src/magick/Magick.java
@@ -5,7 +5,7 @@ import java.awt.Rectangle;
 
 
 /**
- * The sole purchase of this class is to cause the native
+ * The sole purpose of this class is to cause the native
  * library to be loaded whenever a concrete class is used
  * and provide utility methods.
  *


### PR DESCRIPTION
Just a quick simple fix for a typo I saw in the javadocs
