### PR TITLE
Add animated crop support

### DIFF
--- a/src/magick/MagickImage.java
+++ b/src/magick/MagickImage.java
@@ -368,6 +368,22 @@ public class MagickImage extends Magick {
 	throws MagickException;
 
     /**
+     * Composites a set of images while respecting any page offsets and disposal methods.
+     * @see <a href="http://www.imagemagick.org/api/layer.php#CoalesceImages">The underlying ImageMagick call</a>
+     * @exception MagickException on error
+     */
+    public native MagickImage coalesceImages()
+    throws MagickException;
+
+    /**
+     * Returns the coalesced frames of a GIF animation as it would appear after the GIF dispose method of that frame has been applied..
+     * @see <a href="http://www.imagemagick.org/api/layer.php#DisposeImages">The underlying ImageMagick call</a>
+     * @exception MagickException on error
+     */
+    public native MagickImage disposeImages()
+    throws MagickException;
+
+    /**
      * Enhances the intensity differences between the lighter and
      * darker elements of the image.
      * @return a boolean value to indicate success
@@ -1273,6 +1289,16 @@ public class MagickImage extends Magick {
      * @exception MagickException on error
      */
     public native byte[] imageToBlob(ImageInfo imageInfo);
+
+    /**
+     * Returns the image sequence as a blob and its length.
+     *
+     * @param imageInfo the magick member of this object determines
+     *                  output format
+     * @return a byte array containing the image in the specified format
+     * @exception MagickException on error
+     */
+    public native byte[] imagesToBlob(ImageInfo imageInfo);
 
     /**
      * Set the units attribute of the image.

--- a/src/magick/magick_MagickImage.c
+++ b/src/magick/magick_MagickImage.c
@@ -3289,7 +3289,7 @@ JNIEXPORT jbyteArray JNICALL Java_magick_MagickImage_imageToBlob
   }
   (*env)->SetByteArrayRegion(env, blob, 0, blobSiz, blobMem);
 
-  //RelinquishMagickMemory(blobMem);
+  RelinquishMagickMemory(blobMem);
 
   return blob;
 }


### PR DESCRIPTION
Added missing methods to support animated GIF cropping/resizing.
- ImagesToBlob - read all frames of animaged GIF.
- coalesceImages - used for cropping/resizing animated GIF. http://www.imagemagick.org//api/layer.php#CoalesceImages
- disposeImages - used for cropping/resizing animated GIF. http://www.imagemagick.org//api/layer.php#DisposeImages


I didn't add any unit test though.