### PR TITLE
Fix bug in blobToImage

### DIFF
--- a/src/magick/magick_MagickImage.c
+++ b/src/magick/magick_MagickImage.c
@@ -3443,7 +3443,7 @@ JNIEXPORT void JNICALL Java_magick_MagickImage_blobToImage
         DestroyExceptionInfo(exception);
         return;
     }
-    DestroyExceptionInfo(&exception);
+    DestroyExceptionInfo(exception);
 
     /* Get the old image handle and deallocate it (if required). */
     oldImage = (Image*) getHandle(env, self, "magickImageHandle", &fieldID);


### PR DESCRIPTION
`DestroyExceptionInfo()` is supposed to receive a `ExceptionInfo*`, but here it passed in a `ExceptionInfo **`. Looks like a typo bug.

test: Checked that `make simpletest` is passing, and can successfully read from memory buffer.

#24 
@fhlawaczek