### PR TITLE
Fix ImageMagick version format

### DIFF
--- a/jmagick.spec
+++ b/jmagick.spec
@@ -15,7 +15,7 @@
 Summary: open source Java interface of ImageMagick
 Name: jmagick
 # check configure.in, too !
-Version: %(rpm -q --queryformat '%{version}\n' ImageMagick)
+Version: %(awk -F[\.] '{print $1"."$2"."$3}' <<< `rpm -q --queryformat '%{version}\n' ImageMagick`)
 Release: 6
 License: GPL 
 Group: Application/Java


### PR DESCRIPTION
At least on CentOS the latest ImageMagick version is numbered like 6.7.8.9. Because the expected format is only "3-digit" large, the libJMagick.so symlink points to non existent file.
