### PR TITLE
Fixed issues about DrawInfo.setFill() and MagickImage.transformImage() in IM 7.x env

### DIFF
--- a/src/magick/jmagick.c
+++ b/src/magick/jmagick.c
@@ -696,13 +696,8 @@ int getPixelPacket(JNIEnv *env,
                          &green) &&
         getIntFieldValue(env, jPixel, "blue", NULL,
                          &blue) &&
-#if MagickLibVersion < 0x700
 	getIntFieldValue(env, jPixel, "opacity", NULL,
                          &transparency);
-#else
-	getIntFieldValue(env, jPixel, "alpha", NULL,
-                         &transparency);
-#endif
   if (!successful) {
       return successful;
   }

--- a/src/magick/magick_MagickImage.c
+++ b/src/magick/magick_MagickImage.c
@@ -3182,7 +3182,7 @@ JNIEXPORT void JNICALL Java_magick_MagickImage_transformImage
         RectangleInfo geometry;
         MagickStatusType flags=ParseRegionGeometry(transformImage,imageStr,&geometry,exception);
         (void) flags;
-        if ((transformImage->columns != geometry.width) && (transformImage->rows == geometry.height))
+        if ((transformImage->columns != geometry.width) || (transformImage->rows != geometry.height))
         {
             resizeImage=ResizeImage(transformImage,geometry.width,geometry.height,transformImage->filter,exception);
             if (resizeImage != (Image *) NULL)


### PR DESCRIPTION
This pull request fixes 2 issues in ImageMagick 7.x environments.


1. Fixed a bug that makes getPixelPacket() never succeed (Commit 2cf09c9)

Even though the PixelPacket structure of ImageMagick has been changed since IM 7, the corresponding Java class structure has not.

The previous code tries to retrieve 'alpha' field of the PixelPacket Java object, but it always fails because the Java object does not have such field; It has only 'opacity' field.

This bug also makes several JMagic Java methods like magick.DrawInfo.setFill() throw MagicException in ImageMagick 7.x environment.

This pull request will fix those problems.


2. Fixed a bug that makes the resize via transformImage() never succeed (Commit 1e0c8b3)

The corresponding code for ImageMagick 7.x environment checks if the resize is necessary or not. But the condition check code is faulty.
