### PR TITLE
Removed redundant AcquireString() calls to prevent memory leaks

### DIFF
--- a/src/magick/magick_ImageInfo.c
+++ b/src/magick/magick_ImageInfo.c
@@ -72,7 +72,7 @@ JNIEXPORT void JNICALL Java_magick_ImageInfo_setImageOption
         return;                                                               
     }                        
              
-    SetImageOption(info, (char *)AcquireString(cstr1), (char *)AcquireString(cstr2));
+    SetImageOption(info, cstr1, cstr2);
     
     (*env)->ReleaseStringUTFChars(env, option, cstr1);
     (*env)->ReleaseStringUTFChars(env, value, cstr2);                          


### PR DESCRIPTION
These AcquireString() calls are redundant and result in memory leaks.
Inside the SetImageOption() function, the option/value parameters are just copied to the internal data structure and NEVER released.